### PR TITLE
Update to Go 1.11.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-FROM golang:1.11-stretch
+FROM golang:1.11.9-stretch
 
-RUN go get -u github.com/golang/dep/cmd/dep
-
-RUN go get -u golang.org/x/lint/golint
+RUN wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b /usr/bin v1.15.0
 
 RUN apt-get update && apt-get install -y build-essential libssl-dev uuid-dev squashfs-tools


### PR DESCRIPTION
- Remove dep
- Add golangci-lint

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>