### PR TITLE
Upgrade to Go 1.11.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.11-alpine
+FROM golang:1.11.9-alpine3.9
 
 RUN apk add --update git alpine-sdk automake libtool linux-headers libarchive-dev util-linux-dev libuuid openssl-dev gawk sed
 
-RUN go get -u github.com/golang/dep/cmd/dep
+RUN wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b /usr/bin v1.15.0
 


### PR DESCRIPTION
- Remove dep
- Add golangci-lint

Signed-off-by: Marcelo E. Magallon <marcelo@sylabs.io>